### PR TITLE
Enable login via env vars (for CI)

### DIFF
--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -40,14 +40,20 @@ import (
 func RunLogin(ctx context.Context, streams command.Streams, hubClient *hub.Client, store credentials.Store, candidateUsername string) error {
 	username := candidateUsername
 	if username == "" {
+		username = os.Getenv("DOCKER_USERNAME")
+	}
+	if username == "" {
 		var err error
 		if username, err = readClearText(ctx, streams, "Username: "); err != nil {
 			return err
 		}
 	}
-	password, err := readPassword(streams)
-	if err != nil {
-		return err
+	password := os.Getenv("DOCKER_PASSWORD")
+	if password == "" {
+		var err error
+		if password, err = readPassword(streams); err != nil {
+			return err
+		}
 	}
 
 	token, refreshToken, err := Login(ctx, streams, hubClient, username, password)


### PR DESCRIPTION
Signed-off-by: Sean P. Kane <sean@superorbital.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/hub-tool/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Borrowed code from https://github.com/docker/hub-tool/pull/198 to make it possible to login via environment variables for CI workflows.

**- How I did it**

Via a few lines of Go code.

**- How to verify it**

Run `hub-tool logout`

```sh
export DOCKER_USERNAME=hub_username
export DOCKER_PASSWORD=hub_password
hub-tool login
hub-tool tag ls registry
```

* You should not be prompted for the username or password, and you should be able to run other commands now.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* Allow non-interactive login via the `DOCKER_USERNAME` and `DOCKER_PASSWORD` env vars.

